### PR TITLE
fix: reset isForfeit var when game is reset

### DIFF
--- a/js/main.js
+++ b/js/main.js
@@ -221,6 +221,8 @@ let targetDiffScore = 3;
 let gameIsPlayed = false;
 
 function resetGame() {
+  // reset forfeit status for arcade time to run
+  isForfeited = false
   //clear the Timer if present from arcade mode
   document.getElementById("timer-box").style.display = 'none';
   //spawn the knight


### PR DESCRIPTION
Addressing the issue where the arcade mode timer wouldn't run after forfeiting since timer depends on isForfeit evaluating to `false`