### PR TITLE
Add Your Lucky Day achievement

### DIFF
--- a/js/achievements_highscores.js
+++ b/js/achievements_highscores.js
@@ -116,7 +116,15 @@ const achievementList = {
         achievementName: 'Royal Pariah',
         achievementDescrption: 'Have every single piece on the board.',
         achievementStatus: 'Locked',
+        achievementProgress: 0,
         achievementGoal: 6
+    },
+    your_lucky_day : {
+        achievementName: 'Lucky Day',
+        achievementDescrption: 'Avoid potentially getting captured 3 times in a row (drunk mode only)',
+        achievementStatus: 'Locked',
+        achievementProgress: 0,
+        achievementGoal: 3
     }
 };
 
@@ -177,7 +185,12 @@ function checkAchievements() {
     } else {
         playerThreatenedMoves = 0;
     }
+    console.log(playerThreatenedMoves);
+    
     checkAndProgress('threatened', playerThreatenedMoves, 5);
+    if (gameMode == 'drunk') {
+        checkAndProgress('your_lucky_day', playerThreatenedMoves, 3);
+    }
     updateAchievements();
 }
 

--- a/js/achievements_highscores.js
+++ b/js/achievements_highscores.js
@@ -185,7 +185,6 @@ function checkAchievements() {
     } else {
         playerThreatenedMoves = 0;
     }
-    console.log(playerThreatenedMoves);
     
     checkAndProgress('threatened', playerThreatenedMoves, 5);
     if (gameMode == 'drunk') {

--- a/js/piece_object.js
+++ b/js/piece_object.js
@@ -162,8 +162,8 @@ function Piece(type, index) {
             }
 
             if (!possibleMoves.length) return false; // die
-            // check if I can hit the specified square
-            if (possibleMoves.includes(SquareIndex) && gameMode != 'drunk') {
+            // check if I can hit the specified square            
+            if (possibleMoves.includes(SquareIndex)) {
                 return true;
             } else {
                 return false;


### PR DESCRIPTION
Add the Your Lucky Day achievement. Also fix Living Dangerously not working in drunk mode due to faulty logic. This happened due to a check in the canHitSquare function of the piece_object file. The check basically always returned that a piece can't capture a square if the game is in drunk mode, which lead to the 2 achievements mentioned not gaining any progress when using the function. By removing it the Living Dangerously achievement now tracks progress correctly in drunk mode too. Fixes #19 